### PR TITLE
Migrate SFDX Core to SF CLI

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -50,33 +50,33 @@ jobs:
     - name: Install SFDX and plugins
       run: |
         npm install --no-cache @salesforce/cli --global
-        echo 'y' | sfdx plugins:install sfdx-git-delta
-        echo 'y' | sfdx plugins:install sfdx-hardis
+        echo 'y' | sf plugins:install sfdx-git-delta
+        echo 'y' | sf plugins:install sfdx-hardis
     # Calculate delta and set package.xml = delta.xml to deploy only delta changes
-    - name: Configure delta changes for sfdx-hardis and Destructives
+    - name: Calculate delta changes and destructive
       run: |
         mkdir changed-sources
-        sfdx sgd:source:delta --to "HEAD" --from "HEAD^" --output changed-sources/ --generate-delta --source force-app/
+        sf sgd:source:delta --to "HEAD" --from "HEAD^" --output changed-sources/ --generate-delta --source force-app/
         echo $(cat changed-sources/package/package.xml) > manifest/package.xml
         DESTRUCTIVE=$(cat changed-sources/destructiveChanges/destructiveChanges.xml | tr -d '[:space:]''?'\''/\\')       
         echo "DESTRUCTIVE_PACKAGE=$DESTRUCTIVE" >> $GITHUB_ENV
     #login
     - name: Salesforce Authentication
       run:
-        sfdx hardis:auth:login
+        sf hardis:auth:login
     # Deploy runnning All Tests
     - name: Deploy delta - All Tests
       if: ${{env.APEX_TESTS == 'all'}}
       run:
-        sfdx hardis:project:deploy:sources:dx
+        sf hardis:project:deploy:smart --testlevel RunLocalTests
     # Deploy runnning Selected Tests
     - name: Deploy delta - Selected Tests
       if: ${{env.APEX_TESTS != 'all'}}
       run:
-        sfdx hardis:project:deploy:sources:dx -l RunSpecifiedTests -r ${{env.APEX_TESTS}}
+        sf hardis:project:deploy:smart --testlevel RunSpecifiedTests -r ${{env.APEX_TESTS}}
     # Separate async destructive deploy   
     - name: 'Deploy destructive changes (if any)'
       if: contains(env.DESTRUCTIVE_PACKAGE, '<types>')
       run: |
         cat changed-sources/destructiveChanges/destructiveChanges.xml
-        sfdx force:mdapi:deploy -d "changed-sources/destructiveChanges" --ignorewarnings
+        sf project deploy start --async --pre-destructive-changes changed-sources/destructiveChanges/destructiveChanges.xml --manifest changed-sources/destructiveChanges/package.xml --ignore-warnings

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -49,21 +49,21 @@ jobs:
     - name: Install SFDX and plugins
       run: |
         npm install --no-cache @salesforce/cli --global
-        echo 'y' | sfdx plugins:install sfdx-git-delta
-        echo 'y' | sfdx plugins:install @salesforce/sfdx-scanner
-        echo 'y' | sfdx plugins:install sfdx-hardis
+        echo 'y' | sf plugins:install sfdx-git-delta
+        echo 'y' | sf plugins:install @salesforce/sfdx-scanner
+        echo 'y' | sf plugins:install sfdx-hardis
     # Calculate delta (set package.xml = delta.xml) to deploy only delta changes and set destructive
     - name: Configure delta changes and destructive
       run: |
         mkdir changed-sources
-        sfdx sgd:source:delta --to "HEAD" --from "HEAD^" --output changed-sources/ --generate-delta --source force-app/
+        sf sgd:source:delta --to "HEAD" --from "HEAD^" --output changed-sources/ --generate-delta --source force-app/
         echo $(cat changed-sources/package/package.xml) > manifest/package.xml
         DESTRUCTIVE=$(cat changed-sources/destructiveChanges/destructiveChanges.xml | tr -d '[:space:]''?'\''/\\')       
         echo "DESTRUCTIVE_PACKAGE=$DESTRUCTIVE" >> $GITHUB_ENV
     # Scanner
     - name: 'Scan code'
       run: |
-        sfdx scanner:run --format sarif --target './**/*.cls' --category "Design,Best Practices,Performance" --outfile 'apexScanResults.sarif'  
+        sf scanner:run --format sarif --target './**/*.cls' --category "Design,Best Practices,Performance" --outfile 'apexScanResults.sarif'  
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@v3
       with:
@@ -71,20 +71,20 @@ jobs:
     #login
     - name: Salesforce Authentication
       run:
-        sfdx hardis:auth:login
+        sf hardis:auth:login
     # Check deploy runnning All Tests
     - name: Simulate delta deployment - All Tests
       if: ${{env.APEX_TESTS == 'all'}}
       run:
-        sfdx hardis:project:deploy:sources:dx -c
+        sf hardis:project:deploy:smart --check --testlevel RunLocalTests
     # Check deploy runnning Selected Tests
     - name: Simulate delta deployment - Selected Tests
       if: ${{env.APEX_TESTS != 'all'}}
       run:
-        sfdx hardis:project:deploy:sources:dx -c -l RunSpecifiedTests -r ${{env.APEX_TESTS}}
+        sf hardis:project:deploy:smart --check --testlevel RunSpecifiedTests -r ${{env.APEX_TESTS}}
     # Separate async destructive    
     - name: 'Check destructive changes (if any)'
       if: contains(env.DESTRUCTIVE_PACKAGE, '<types>')
       run: |
         cat changed-sources/destructiveChanges/destructiveChanges.xml
-        sfdx force:mdapi:deploy -d "changed-sources/destructiveChanges" --checkonly --ignorewarnings
+        sf project deploy start --dry-run --async --pre-destructive-changes changed-sources/destructiveChanges/destructiveChanges.xml --manifest changed-sources/destructiveChanges/package.xml --ignore-warnings

--- a/force-app/main/default/classes/Utils.cls
+++ b/force-app/main/default/classes/Utils.cls
@@ -1,4 +1,4 @@
-//Used only for test deploys.
+//Used only for test deploys
 public without sharing class Utils {
     public static integer getSum(Integer a, Integer b) {
         return a+b;

--- a/parsePR.js
+++ b/parsePR.js
@@ -16,7 +16,10 @@ async function extractTests(){
         //special delimeter for apex tests
         if(line.includes('Apex::[') && line.includes(']::Apex')){
 
-            let tests = line.substring(8,line.length-7).replaceAll("]","");
+            let tests = line.substring(8, line.length - 7).replaceAll("]", "").replaceAll(","," ");
+            if(tests != 'all'){// Add double quotes around test classes to run
+                tests = `"${tests}"`;
+            }
             await fs.promises.writeFile(testsFile,tests);
             await fs.promises.appendFile(testsFile,'\n');
         }


### PR DESCRIPTION
### Description

- Supports multiple selected test classes on validations/deploys (separated by comma or space, supporting both)
- Migrate commands from SFDX core to SF CLI core
- Update sfdx-hardis commands based on [v5.0.1](https://github.com/hardisgroupcom/sfdx-hardis/releases/tag/v5.0.1)
- Replace the deprecated `force:mdapi:deploy` with the new `sf project deploy` (Based on [sfdx-git-delta README](https://github.com/scolladon/sfdx-git-delta/blob/main/README.md) example).

### Tests to Run

Apex::[all]::Apex